### PR TITLE
Add Preg::isMatch and Preg::isMatchAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ the fact that they can only be strings (for replace), ints (for match) or arrays
 Similarly, due to type safety requirements matching using PREG_OFFSET_CAPTURE is made available via
 `matchWithOffset` and `matchAllWithOffset`. You cannot pass the flag to `match`/`matchAll`.
 
+Additionally the `Preg` class provides match methods that return `bool` rather than `int`, for stricter type safety
+when the number of pattern matches is not useful:
+
+```php
+use Composer\Pcre\Preg;
+
+if (Preg::isMatch('{fo+}', $string, $matches)) // bool
+if (Preg::isMatchAll('{fo+}', $string, $matches, PREG_OFFSET_CAPTURE)) // bool
+```
+
 If you would prefer a slightly more verbose usage, replacing by-ref arguments by result objects, you can use the `Regex` class:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ when the number of pattern matches is not useful:
 use Composer\Pcre\Preg;
 
 if (Preg::isMatch('{fo+}', $string, $matches)) // bool
-if (Preg::isMatchAll('{fo+}', $string, $matches, PREG_OFFSET_CAPTURE)) // bool
+if (Preg::isMatchAll('{fo+}', $string, $matches)) // bool
 ```
 
 If you would prefer a slightly more verbose usage, replacing by-ref arguments by result objects, you can use the `Regex` class:

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -214,4 +214,30 @@ class Preg
 
         return $result;
     }
+
+    /**
+     * @param string   $pattern
+     * @param string   $subject
+     * @param array<string|null> $matches Set by method
+     * @param int      $flags PREG_UNMATCHED_AS_NULL, only available on PHP 7.2+
+     * @param int      $offset
+     * @return bool
+     */
+    public static function isMatch($pattern, $subject, &$matches = null, $flags = 0, $offset = 0)
+    {
+        return (bool) static::match($pattern, $subject, $matches, $flags, $offset);
+    }
+
+    /**
+     * @param string   $pattern
+     * @param string   $subject
+     * @param array<string|null> $matches Set by method
+     * @param int      $flags PREG_UNMATCHED_AS_NULL, only available on PHP 7.2+
+     * @param int      $offset
+     * @return bool
+     */
+    public static function isMatchAll($pattern, $subject, &$matches = null, $flags = 0, $offset = 0)
+    {
+        return (bool) static::matchAll($pattern, $subject, $matches, $flags, $offset);
+    }
 }

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -231,7 +231,7 @@ class Preg
     /**
      * @param string   $pattern
      * @param string   $subject
-     * @param array<string|null> $matches Set by method
+     * @param array<int|string, list<string|null>> $matches Set by method
      * @param int      $flags PREG_UNMATCHED_AS_NULL, only available on PHP 7.2+
      * @param int      $offset
      * @return bool

--- a/tests/PregTests/IsMatchAllTest.php
+++ b/tests/PregTests/IsMatchAllTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre\PregTests;
+
+use Composer\Pcre\BaseTestCase;
+use Composer\Pcre\Preg;
+
+class IsMatchAllTest extends BaseTestCase
+{
+    /**
+     * This can be replaced with a setUp() method when appropriate
+     *
+     * @before
+     * @return void
+     */
+    public function registerFunctionName()
+    {
+        $this->pregFunction = 'preg_match_all()';
+    }
+
+    /**
+     * @return void
+     */
+    public function testSuccess()
+    {
+        $result = Preg::isMatchAll('{[aei]}', 'abcdefghijklmnopqrstuvwxyz', $matches);
+        $this->assertSame(true, $result);
+        $this->assertSame(array(0 => array('a', 'e', 'i')), $matches);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSuccessNoRef()
+    {
+        $result = Preg::isMatchAll('{[aei]}', 'abcdefghijklmnopqrstuvwxyz');
+        $this->assertSame(true, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFailure()
+    {
+        $result = Preg::isMatchAll('{abc}', 'def', $matches);
+        $this->assertSame(false, $result);
+        $this->assertSame(array(array()), $matches);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBadPatternThrowsIfWarningsAreNotThrowing()
+    {
+        $this->expectPcreException($pattern = '{[aei]');
+        @Preg::isMatchAll($pattern, 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    /**
+     * @return void
+     */
+    public function testBadPatternTriggersWarningByDefault()
+    {
+        $this->expectPcreWarning();
+        Preg::isMatchAll('{[aei]', 'abcdefghijklmnopqrstuvwxyz');
+    }
+}

--- a/tests/PregTests/IsMatchTest.php
+++ b/tests/PregTests/IsMatchTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre\PregTests;
+
+use Composer\Pcre\BaseTestCase;
+use Composer\Pcre\Preg;
+
+class IsMatchTest extends BaseTestCase
+{
+    /**
+     * This can be replaced with a setUp() method when appropriate
+     *
+     * @before
+     * @return void
+     */
+    public function registerFunctionName()
+    {
+        $this->pregFunction = 'preg_match()';
+    }
+
+    /**
+     * @return void
+     */
+    public function testSuccess()
+    {
+        $result = Preg::isMatch('{(?P<m>[io])}', 'abcdefghijklmnopqrstuvwxyz', $matches);
+        $this->assertSame(true, $result);
+        $this->assertSame(array(0 => 'i', 'm' => 'i', 1 => 'i'), $matches);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSuccessNoRef()
+    {
+        $result = Preg::isMatch('{(?P<m>[io])}', 'abcdefghijklmnopqrstuvwxyz');
+        $this->assertSame(true, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFailure()
+    {
+        $result = Preg::isMatch('{abc}', 'def', $matches);
+        $this->assertSame(false, $result);
+        $this->assertSame(array(), $matches);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBadPatternThrowsIfWarningsAreNotThrowing()
+    {
+        $this->expectPcreException($pattern = '{(?P<m>[io])');
+        @Preg::isMatch($pattern, 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    /**
+     * @return void
+     */
+    public function testBadPatternTriggersWarningByDefault()
+    {
+        $this->expectPcreWarning();
+        Preg::isMatch('{(?P<m>[io])', 'abcdefghijklmnopqrstuvwxyz');
+    }
+}


### PR DESCRIPTION
More syntax sugar, returning `bool` from _preg_match_ and _preg_match_all_ whilst allowing the use of all parameters. These methods make the `Preg` class a complete drop-in replacement for the native functions.

What do you think?