### PR TITLE
Simplify matching: Match first / match firstOf

### DIFF
--- a/src/MatchFirstResult.php
+++ b/src/MatchFirstResult.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre;
+
+final class MatchFirstResult
+{
+    /**
+     * First found match (first group or match)
+     *
+     * @readonly
+     * @var string|null
+     */
+    public $match;
+
+    /**
+     * @readonly
+     * @var bool
+     */
+    public $matched;
+
+    /**
+     * @param 0|positive-int $count
+     * @param array<string|null> $matches
+     */
+    public function __construct($count, array $matches)
+    {
+        $this->matched = (bool) $count;
+        $this->match = $this->matched ? $matches[1] ?? $matches[0] : null;
+    }
+}

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -27,9 +27,7 @@ class Regex
      */
     public static function match(string $pattern, string $subject, int $flags = 0, int $offset = 0): MatchResult
     {
-        if (($flags & PREG_OFFSET_CAPTURE) !== 0) {
-            throw new \InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the return type, use matchWithOffsets() instead');
-        }
+        self::checkOffsetCapture($flags);
 
         $count = Preg::match($pattern, $subject, $matches, $flags, $offset);
 
@@ -55,9 +53,7 @@ class Regex
      */
     public static function matchAll(string $pattern, string $subject, int $flags = 0, int $offset = 0): MatchAllResult
     {
-        if (($flags & PREG_OFFSET_CAPTURE) !== 0) {
-            throw new \InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the return type, use matchAllWithOffsets() instead');
-        }
+        self::checkOffsetCapture($flags);
 
         if (($flags & PREG_SET_ORDER) !== 0) {
             throw new \InvalidArgumentException('PREG_SET_ORDER is not supported as it changes the return type');
@@ -114,5 +110,12 @@ class Regex
         $result = Preg::replaceCallbackArray($pattern, $subject, $limit, $count, $flags);
 
         return new ReplaceResult($count, $result);
+    }
+
+    protected static function checkOffsetCapture(int $flags): void
+    {
+        if (($flags & PREG_OFFSET_CAPTURE) !== 0) {
+            throw new \InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the return type, use matchWithOffsets() instead');
+        }
     }
 }

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -35,6 +35,43 @@ class Regex
     }
 
     /**
+     * @param non-empty-string $pattern
+     * @param int    $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     */
+    public static function matchFirst(string $pattern, string $subject, int $flags = 0, int $offset = 0): MatchFirstResult
+    {
+        self::checkOffsetCapture($flags);
+
+        $count = Preg::match($pattern, $subject, $matches, $flags, $offset);
+
+        return new MatchFirstResult($count, $matches);
+    }
+
+    /**
+     * @param array<non-empty-string> $patterns
+     * @param int    $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     */
+    public static function matchFirstOf(array $patterns, string $subject, int $flags = 0, int $offset = 0): MatchFirstResult
+    {
+        self::checkOffsetCapture($flags);
+
+        if ($patterns === []) {
+            throw new \LogicException('You have provided an empty patterns.');
+        }
+
+        $match = null; // Make PHPStan/IDE happy
+        foreach ($patterns as $pattern) {
+            $match = self::matchFirst($pattern, $subject, $flags, $offset);
+
+            if ($match->matched === true) {
+                return $match;
+            }
+        }
+
+        return $match;
+    }
+
+    /**
      * Runs preg_match with PREG_OFFSET_CAPTURE
      *
      * @param non-empty-string $pattern

--- a/tests/RegexTests/MatchFirstOfTest.php
+++ b/tests/RegexTests/MatchFirstOfTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre\RegexTests;
+
+use Composer\Pcre\BaseTestCase;
+use Composer\Pcre\MatchFirstResult;
+use Composer\Pcre\Regex;
+
+class MatchFirstOfTest extends BaseTestCase
+{
+    private const REGEX = ['/width="([\d]+)"/', '/w=([\d]+)px/'];
+
+    public function setUp(): void
+    {
+        $this->pregFunction = 'preg_match()';
+    }
+
+    public function testSuccessFirstMatch(): void
+    {
+        $result = Regex::matchFirstOf(self::REGEX, 'width="30"');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertTrue($result->matched);
+        self::assertSame('30', $result->match);
+    }
+
+    public function testSuccessSecondMatch(): void
+    {
+        $result = Regex::matchFirstOf(self::REGEX, 'w=32px');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertTrue($result->matched);
+        self::assertSame('32', $result->match);
+    }
+
+    public function testFailure(): void
+    {
+        $result = Regex::matchFirstOf(self::REGEX, 'test');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertFalse($result->matched);
+        self::assertSame(null, $result->match);
+    }
+
+    public function testBadPatternThrowsIfWarningsAreNotThrowing(): void
+    {
+        $this->expectPcreException($pattern = '{abc');
+        @Regex::matchFirstOf([$pattern], 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    public function testBadPatternTriggersWarningByDefault(): void
+    {
+        $this->expectPcreWarning();
+        Regex::matchFirstOf(['{abc'], 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    public function testThrowsIfEngineErrors(): void
+    {
+        $this->expectPcreEngineException($pattern = '/(?:\D+|<\d+>)*[!?]/');
+        Regex::matchFirstOf([$pattern], 'foobar foobar foobar');
+    }
+}

--- a/tests/RegexTests/MatchFirstTest.php
+++ b/tests/RegexTests/MatchFirstTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre\RegexTests;
+
+use Composer\Pcre\BaseTestCase;
+use Composer\Pcre\MatchFirstResult;
+use Composer\Pcre\Regex;
+
+class MatchFirstTest extends BaseTestCase
+{
+    private const REGEX = '/test=([\w]+)/';
+
+    public function setUp(): void
+    {
+        $this->pregFunction = 'preg_match()';
+    }
+
+    public function testSuccessFirstMatch(): void
+    {
+        $result = Regex::matchFirst(self::REGEX, 'test=rock');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertTrue($result->matched);
+        self::assertSame('rock', $result->match);
+    }
+
+    public function testSuccessSecondMatch(): void
+    {
+        $result = Regex::matchFirst(self::REGEX, 'test=32');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertTrue($result->matched);
+        self::assertSame('32', $result->match);
+    }
+
+    public function testFailure(): void
+    {
+        $result = Regex::matchFirst(self::REGEX, 'test');
+        self::assertInstanceOf(MatchFirstResult::class, $result);
+        self::assertFalse($result->matched);
+        self::assertSame(null, $result->match);
+    }
+
+    public function testBadPatternThrowsIfWarningsAreNotThrowing(): void
+    {
+        $this->expectPcreException($pattern = '{abc');
+        @Regex::matchFirst($pattern, 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    public function testBadPatternTriggersWarningByDefault(): void
+    {
+        $this->expectPcreWarning();
+        Regex::matchFirst('{abc', 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    public function testThrowsIfEngineErrors(): void
+    {
+        $this->expectPcreEngineException($pattern = '/(?:\D+|<\d+>)*[!?]/');
+        Regex::matchFirst($pattern, 'foobar foobar foobar');
+    }
+}

--- a/tests/RegexTests/ReplaceCallbackTest.php
+++ b/tests/RegexTests/ReplaceCallbackTest.php
@@ -36,7 +36,7 @@ class ReplaceCallbackTest extends BaseTestCase
 
     public function testFailure(): void
     {
-       $result = Regex::replaceCallback('{abc}', function ($match) {
+        $result = Regex::replaceCallback('{abc}', function ($match) {
             return '('.$match[0].')';
         }, 'def');
 


### PR DESCRIPTION
Hi,

thank you for the package, this is what I was looking for (I do like that you are using "result" objects).

- Anyway I often need to match first group or - `matchFirst`
- Also sometimes I need to try multiple regexes on the subject - `matchFirstOf`

## Checklist

- [X] PHP CS Fixer
- [X] Add tests
- [X] PHPStan
- [X] Explanation in commit messages (long message)
- [ ] Documentation

Are you OK with the changes?

Thank you,

## FYI

### PHPStan

There are 2 phpstan errors. Not sure how to fix it (I used PHP 8.1).

```
> phpstan analyse
Note: Using configuration file /Users/pion/Work/OpenSource/pcre/phpstan.neon.dist.
  0/33 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%[1G[2K 33/33 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------- 
  Line   src/Preg.php                                                          
 ------ ---------------------------------------------------------------------- 
  78     Strict comparison using === between int<0, max> and null will always  
         evaluate to false.                                                    
  98     Strict comparison using === between int<0, max> and null will always  
         evaluate to false.                                                    
 ------ ---------------------------------------------------------------------- 


 [ERROR] Found 2 errors        
```

### Linting

In contribution we are instructed to use PHP CS fixer. Maybe would be great to require as dev dependency and add config + composer script? (I personally use [ECS package](https://github.com/symplify/easy-coding-standard)