### PR TITLE
[2.x/3.x] Add matchNotNull and other *NotNull implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ if (Preg::isMatch('{fo+}', $string, $matches)) // bool
 if (Preg::isMatchAll('{fo+}', $string, $matches)) // bool
 ```
 
+Finally the `Preg` class provides a few `*StrictGroups` method variants that ensure match groups
+are always present and thus non-nullable, making it easier to write type-safe code:
+
+```php
+use Composer\Pcre\Preg;
+
+// $matches is guaranteed to be an array of strings, if a subpattern does not match and produces a null it will throw
+if (Preg::matchStrictGroups('{fo+}', $string, $matches))
+if (Preg::matchAllStrictGroups('{fo+}', $string, $matches))
+```
+
 If you would prefer a slightly more verbose usage, replacing by-ref arguments by result objects, you can use the `Regex` class:
 
 ```php

--- a/src/MatchAllResult.php
+++ b/src/MatchAllResult.php
@@ -35,9 +35,9 @@ final class MatchAllResult
 
     /**
      * @param 0|positive-int $count
-     * @param array<array<string|null>> $matches
+     * @param array<int|string, array<string|null>> $matches
      */
-    public function __construct($count, array $matches)
+    public function __construct(int $count, array $matches)
     {
         $this->matches = $matches;
         $this->matched = (bool) $count;

--- a/src/MatchAllStrictGroupsResult.php
+++ b/src/MatchAllStrictGroupsResult.php
@@ -11,14 +11,13 @@
 
 namespace Composer\Pcre;
 
-final class MatchAllWithOffsetsResult
+final class MatchAllStrictGroupsResult
 {
     /**
-     * An array of match group => list of matches, every match being a pair of string matched + offset in bytes (or -1 if no match)
+     * An array of match group => list of matched strings
      *
      * @readonly
-     * @var array<int|string, list<array{string|null, int}>>
-     * @phpstan-var array<int|string, list<array{string|null, int<-1, max>}>>
+     * @var array<int|string, list<string>>
      */
     public $matches;
 
@@ -36,8 +35,7 @@ final class MatchAllWithOffsetsResult
 
     /**
      * @param 0|positive-int $count
-     * @param array<int|string, list<array{string|null, int}>> $matches
-     * @phpstan-param array<int|string, list<array{string|null, int<-1, max>}>> $matches
+     * @param array<array<string>> $matches
      */
     public function __construct(int $count, array $matches)
     {

--- a/src/MatchResult.php
+++ b/src/MatchResult.php
@@ -31,7 +31,7 @@ final class MatchResult
      * @param 0|positive-int $count
      * @param array<string|null> $matches
      */
-    public function __construct($count, array $matches)
+    public function __construct(int $count, array $matches)
     {
         $this->matches = $matches;
         $this->matched = (bool) $count;

--- a/src/MatchStrictGroupsResult.php
+++ b/src/MatchStrictGroupsResult.php
@@ -11,22 +11,15 @@
 
 namespace Composer\Pcre;
 
-final class MatchAllWithOffsetsResult
+final class MatchStrictGroupsResult
 {
     /**
-     * An array of match group => list of matches, every match being a pair of string matched + offset in bytes (or -1 if no match)
+     * An array of match group => string matched
      *
      * @readonly
-     * @var array<int|string, list<array{string|null, int}>>
-     * @phpstan-var array<int|string, list<array{string|null, int<-1, max>}>>
+     * @var array<int|string, string>
      */
     public $matches;
-
-    /**
-     * @readonly
-     * @var 0|positive-int
-     */
-    public $count;
 
     /**
      * @readonly
@@ -36,13 +29,11 @@ final class MatchAllWithOffsetsResult
 
     /**
      * @param 0|positive-int $count
-     * @param array<int|string, list<array{string|null, int}>> $matches
-     * @phpstan-param array<int|string, list<array{string|null, int<-1, max>}>> $matches
+     * @param array<string> $matches
      */
     public function __construct(int $count, array $matches)
     {
         $this->matches = $matches;
         $this->matched = (bool) $count;
-        $this->count = $count;
     }
 }

--- a/src/MatchWithOffsetsResult.php
+++ b/src/MatchWithOffsetsResult.php
@@ -33,7 +33,7 @@ final class MatchWithOffsetsResult
      * @param array<array{string|null, int}> $matches
      * @phpstan-param array<int|string, array{string|null, int<-1, max>}> $matches
      */
-    public function __construct($count, array $matches)
+    public function __construct(int $count, array $matches)
     {
         $this->matches = $matches;
         $this->matched = (bool) $count;

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -39,6 +39,25 @@ class Preg
     }
 
     /**
+     * Variant of `match()` which outputs non-null matches (or throws)
+     *
+     * @param non-empty-string $pattern
+     * @param array<string> $matches Set by method
+     * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     * @return 0|1
+     * @throws UnexpectedNullMatchException
+     *
+     * @param-out array<int|string, string> $matches
+     */
+    public static function matchStrictGroups(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
+    {
+        $result = self::match($pattern, $subject, $matchesInternal, $flags, $offset);
+        $matches = self::enforceNonNullMatches($pattern, $matchesInternal, 'match');
+
+        return $result;
+    }
+
+    /**
      * Runs preg_match with PREG_OFFSET_CAPTURE
      *
      * @param non-empty-string   $pattern
@@ -61,7 +80,7 @@ class Preg
     /**
      * @param non-empty-string   $pattern
      * @param array<int|string, list<string|null>> $matches Set by method
-     * @param int-mask<PREG_UNMATCHED_AS_NULL|PREG_SET_ORDER> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
      * @return 0|positive-int
      *
      * @param-out array<int|string, list<string|null>> $matches
@@ -69,15 +88,31 @@ class Preg
     public static function matchAll(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
     {
         self::checkOffsetCapture($flags, 'matchAllWithOffsets');
-
-        if (($flags & PREG_SET_ORDER) !== 0) {
-            throw new \InvalidArgumentException('PREG_SET_ORDER is not supported as it changes the type of $matches');
-        }
+        self::checkSetOrder($flags);
 
         $result = preg_match_all($pattern, $subject, $matches, $flags | PREG_UNMATCHED_AS_NULL, $offset);
         if (!is_int($result)) { // PHP < 8 may return null, 8+ returns int|false
             throw PcreException::fromFunction('preg_match_all', $pattern);
         }
+
+        return $result;
+    }
+
+    /**
+     * Variant of `match()` which outputs non-null matches (or throws)
+     *
+     * @param non-empty-string   $pattern
+     * @param array<int|string, list<string|null>> $matches Set by method
+     * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     * @return 0|positive-int
+     * @throws UnexpectedNullMatchException
+     *
+     * @param-out array<int|string, list<string>> $matches
+     */
+    public static function matchAllStrictGroups(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): int
+    {
+        $result = self::matchAll($pattern, $subject, $matchesInternal, $flags, $offset);
+        $matches = self::enforceNonNullMatchAll($pattern, $matchesInternal, 'matchAll');
 
         return $result;
     }
@@ -94,6 +129,8 @@ class Preg
      */
     public static function matchAllWithOffsets(string $pattern, string $subject, ?array &$matches, int $flags = 0, int $offset = 0): int
     {
+        self::checkSetOrder($flags);
+
         $result = preg_match_all($pattern, $subject, $matches, $flags | PREG_UNMATCHED_AS_NULL | PREG_OFFSET_CAPTURE, $offset);
         if (!is_int($result)) { // PHP < 8 may return null, 8+ returns int|false
             throw PcreException::fromFunction('preg_match_all', $pattern);
@@ -241,6 +278,8 @@ class Preg
     }
 
     /**
+     * Variant of match() which returns a bool instead of int
+     *
      * @param non-empty-string   $pattern
      * @param array<string|null> $matches Set by method
      * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
@@ -253,6 +292,23 @@ class Preg
     }
 
     /**
+     * Variant of `isMatch()` which outputs non-null matches (or throws)
+     *
+     * @param non-empty-string $pattern
+     * @param array<string> $matches Set by method
+     * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     * @throws UnexpectedNullMatchException
+     *
+     * @param-out array<int|string, string> $matches
+     */
+    public static function isMatchStrictGroups(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): bool
+    {
+        return (bool) self::matchStrictGroups($pattern, $subject, $matches, $flags, $offset);
+    }
+
+    /**
+     * Variant of matchAll() which returns a bool instead of int
+     *
      * @param non-empty-string   $pattern
      * @param array<int|string, list<string|null>> $matches Set by method
      * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
@@ -265,6 +321,22 @@ class Preg
     }
 
     /**
+     * Variant of `isMatchAll()` which outputs non-null matches (or throws)
+     *
+     * @param non-empty-string $pattern
+     * @param array<int|string, list<string>> $matches Set by method
+     * @param int-mask<PREG_UNMATCHED_AS_NULL> $flags PREG_UNMATCHED_AS_NULL is always set, no other flags are supported
+     *
+     * @param-out array<int|string, list<string>> $matches
+     */
+    public static function isMatchAllStrictGroups(string $pattern, string $subject, ?array &$matches = null, int $flags = 0, int $offset = 0): bool
+    {
+        return (bool) self::matchAllStrictGroups($pattern, $subject, $matches, $flags, $offset);
+    }
+
+    /**
+     * Variant of matchWithOffsets() which returns a bool instead of int
+     *
      * Runs preg_match with PREG_OFFSET_CAPTURE
      *
      * @param non-empty-string   $pattern
@@ -279,6 +351,8 @@ class Preg
     }
 
     /**
+     * Variant of matchAllWithOffsets() which returns a bool instead of int
+     *
      * Runs preg_match_all with PREG_OFFSET_CAPTURE
      *
      * @param non-empty-string   $pattern
@@ -297,5 +371,48 @@ class Preg
         if (($flags & PREG_OFFSET_CAPTURE) !== 0) {
             throw new \InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the type of $matches, use ' . $useFunctionName . '() instead');
         }
+    }
+
+    private static function checkSetOrder(int $flags): void
+    {
+        if (($flags & PREG_SET_ORDER) !== 0) {
+            throw new \InvalidArgumentException('PREG_SET_ORDER is not supported as it changes the type of $matches');
+        }
+    }
+
+    /**
+     * @param array<int|string, string|null> $matches
+     * @return array<int|string, string>
+     * @throws UnexpectedNullMatchException
+     */
+    private static function enforceNonNullMatches(string $pattern, array $matches, string $variantMethod)
+    {
+        foreach ($matches as $group => $match) {
+            if (null === $match) {
+                throw new UnexpectedNullMatchException('Pattern "'.$pattern.'" had an unexpected unmatched group "'.$group.'", make sure the pattern always matches or use '.$variantMethod.'() instead.');
+            }
+        }
+
+        /** @var array<string> */
+        return $matches;
+    }
+
+    /**
+     * @param array<int|string, list<string|null>> $matches
+     * @return array<int|string, list<string>>
+     * @throws UnexpectedNullMatchException
+     */
+    private static function enforceNonNullMatchAll(string $pattern, array $matches, string $variantMethod)
+    {
+        foreach ($matches as $group => $groupMatches) {
+            foreach ($groupMatches as $match) {
+                if (null === $match) {
+                    throw new UnexpectedNullMatchException('Pattern "'.$pattern.'" had an unexpected unmatched group "'.$group.'", make sure the pattern always matches or use '.$variantMethod.'() instead.');
+                }
+            }
+        }
+
+        /** @var array<int|string, list<string>> */
+        return $matches;
     }
 }

--- a/src/ReplaceResult.php
+++ b/src/ReplaceResult.php
@@ -33,9 +33,8 @@ final class ReplaceResult
 
     /**
      * @param 0|positive-int $count
-     * @param string $result
      */
-    public function __construct($count, $result)
+    public function __construct(int $count, string $result)
     {
         $this->count = $count;
         $this->matched = (bool) $count;

--- a/src/UnexpectedNullMatchException.php
+++ b/src/UnexpectedNullMatchException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of composer/pcre.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Pcre;
+
+class UnexpectedNullMatchException extends PcreException
+{
+    public static function fromFunction($function, $pattern)
+    {
+        throw new \LogicException('fromFunction should not be called on '.self::class.', use '.PcreException::class);
+    }
+}

--- a/tests/PregTests/MatchAllTest.php
+++ b/tests/PregTests/MatchAllTest.php
@@ -13,6 +13,7 @@ namespace Composer\Pcre\PregTests;
 
 use Composer\Pcre\BaseTestCase;
 use Composer\Pcre\Preg;
+use Composer\Pcre\UnexpectedNullMatchException;
 
 class MatchAllTest extends BaseTestCase
 {
@@ -39,6 +40,20 @@ class MatchAllTest extends BaseTestCase
         $count = Preg::matchAll('{abc}', 'def', $matches);
         self::assertSame(0, $count);
         self::assertSame(array(array()), $matches);
+    }
+
+    public function testSuccessStrictGroups(): void
+    {
+        $count = Preg::matchAllStrictGroups('{(?P<m>\d)(?<matched>a)?}', '3a', $matches);
+        self::assertSame(1, $count);
+        self::assertSame(array(0 => ['3a'], 'm' => ['3'], 1 => ['3'], 'matched' => ['a'], 2 => ['a']), $matches);
+    }
+
+    public function testFailStrictGroups(): void
+    {
+        self::expectException(UnexpectedNullMatchException::class);
+        self::expectExceptionMessage('Pattern "{(?P<m>\d)(?<unmatched>b)?}" had an unexpected unmatched group "unmatched", make sure the pattern always matches or use matchAll() instead.');
+        Preg::matchAllStrictGroups('{(?P<m>\d)(?<unmatched>b)?}', '123', $matches);
     }
 
     public function testBadPatternThrowsIfWarningsAreNotThrowing(): void

--- a/tests/PregTests/MatchTest.php
+++ b/tests/PregTests/MatchTest.php
@@ -13,6 +13,7 @@ namespace Composer\Pcre\PregTests;
 
 use Composer\Pcre\BaseTestCase;
 use Composer\Pcre\Preg;
+use Composer\Pcre\UnexpectedNullMatchException;
 
 class MatchTest extends BaseTestCase
 {
@@ -33,6 +34,20 @@ class MatchTest extends BaseTestCase
         $count = Preg::match('{(?P<m>\d)}', 123, $matches); // @phpstan-ignore-line
         self::assertSame(1, $count);
         self::assertSame(array(0 => '1', 'm' => '1', 1 => '1'), $matches);
+    }
+
+    public function testSuccessStrictGroups(): void
+    {
+        $count = Preg::matchStrictGroups('{(?P<m>\d)(?<matched>a)?}', '3a', $matches);
+        self::assertSame(1, $count);
+        self::assertSame(array(0 => '3a', 'm' => '3', 1 => '3', 'matched' => 'a', 2 => 'a'), $matches);
+    }
+
+    public function testFailStrictGroups(): void
+    {
+        self::expectException(UnexpectedNullMatchException::class);
+        self::expectExceptionMessage('Pattern "{(?P<m>\d)(?<unmatched>b)?}" had an unexpected unmatched group "unmatched", make sure the pattern always matches or use match() instead.');
+        Preg::matchStrictGroups('{(?P<m>\d)(?<unmatched>b)?}', '123', $matches);
     }
 
     public function testTypeErrorWithNull(): void

--- a/tests/RegexTests/MatchTest.php
+++ b/tests/RegexTests/MatchTest.php
@@ -13,6 +13,7 @@ namespace Composer\Pcre\RegexTests;
 
 use Composer\Pcre\BaseTestCase;
 use Composer\Pcre\Regex;
+use Composer\Pcre\UnexpectedNullMatchException;
 
 class MatchTest extends BaseTestCase
 {
@@ -35,6 +36,19 @@ class MatchTest extends BaseTestCase
         self::assertInstanceOf('Composer\Pcre\MatchResult', $result);
         self::assertFalse($result->matched);
         self::assertSame(array(), $result->matches);
+    }
+
+    public function testSuccessStrictGroups(): void
+    {
+        $result = Regex::matchStrictGroups('{(?P<m>\d)(?<matched>a)?}', '3a');
+        self::assertSame(array(0 => '3a', 'm' => '3', 1 => '3', 'matched' => 'a', 2 => 'a'), $result->matches);
+    }
+
+    public function testFailStrictGroups(): void
+    {
+        self::expectException(UnexpectedNullMatchException::class);
+        self::expectExceptionMessage('Pattern "{(?P<m>\d)(?<unmatched>b)?}" had an unexpected unmatched group "unmatched", make sure the pattern always matches or use match() instead.');
+        Regex::matchStrictGroups('{(?P<m>\d)(?<unmatched>b)?}', '123');
     }
 
     public function testBadPatternThrowsIfWarningsAreNotThrowing(): void


### PR DESCRIPTION
I'd be happy for a sanity check here before proceeding and adding the rest of them (matchWithOffsetsNotNull, matchAllNotNull, matchAllWithOffsetsNotNull, replaceCallbackNotNull, replaceCallbackArrayNotNull, isMatchNotNull, isMatchAllNotNull, isMatchWithOffsetsNotNull, isMatchAllWithOffsetsNotNull 😅 ).

The issue is that due to the improvements in PHPStan and https://github.com/composer/pcre/releases/tag/3.0.2 you now get errors everywhere because `$match[1]` for ex is `string|null` even tho in many cases the null will never happen. This is however dependent on the pattern and thus cannot really be asserted easily in the types.

So adding these NotNull variants for all functions outputting nullable matches solves this by letting you opt in to stricter non-nullable types, and if you messed up and your pattern does have null/unmatched-subpatterns you get an exception.

The main problems I see and where I'd love feedback are:

- is the NotNull name clear/confusing?
- is it polluting the interface too much? It adds lots of "duplicate" methods but they are technically different and kinda similar to the WithOffset ones we already have. This makes me think perhaps the name should be WithoutNull tho. 

/cc @johnstevenson @naderman @stof