### PR TITLE
[3.x] Add replaceCallbackStrictGroups 

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -193,6 +193,24 @@ class Preg
     }
 
     /**
+     * Variant of `replaceCallback()` which outputs non-null matches (or throws)
+     *
+     * @param string $pattern
+     * @param callable(array<int|string, string>): string $replacement
+     * @param string $subject
+     * @param int $count Set by method
+     * @param int-mask<PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE> $flags PREG_OFFSET_CAPTURE or PREG_UNMATCHED_AS_NULL, only available on PHP 7.4+
+     *
+     * @param-out int<0, max> $count
+     */
+    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    {
+        return self::replaceCallback($pattern, function (array $matches) use ($pattern, $replacement) {
+            return $replacement(self::enforceNonNullMatches($pattern, $matches, 'replaceCallback'));
+        }, $subject, $limit, $count, $flags);
+    }
+
+    /**
      * @param array<string, callable(array<int|string, string|null>): string> $pattern
      * @param string $subject
      * @param int    $count Set by method

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -132,6 +132,21 @@ class Regex
     }
 
     /**
+     * Variant of `replaceCallback()` which outputs non-null matches (or throws)
+     *
+     * @param string $pattern
+     * @param callable(array<int|string, string>): string $replacement
+     * @param string          $subject
+     * @param int-mask<PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE> $flags PREG_OFFSET_CAPTURE or PREG_UNMATCHED_AS_NULL, only available on PHP 7.4+
+     */
+    public static function replaceCallbackStrictGroups($pattern, callable $replacement, $subject, int $limit = -1, int $flags = 0): ReplaceResult
+    {
+        $result = Preg::replaceCallbackStrictGroups($pattern, $replacement, $subject, $limit, $count, $flags);
+
+        return new ReplaceResult($count, $result);
+    }
+
+    /**
      * @param array<string, callable(array<int|string, string|null>): string> $pattern
      * @param string $subject
      * @param int-mask<PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE> $flags PREG_OFFSET_CAPTURE is supported, PREG_UNMATCHED_AS_NULL is always set

--- a/tests/PregTests/ReplaceCallbackTest.php
+++ b/tests/PregTests/ReplaceCallbackTest.php
@@ -13,6 +13,7 @@ namespace Composer\Pcre\PregTests;
 
 use Composer\Pcre\BaseTestCase;
 use Composer\Pcre\Preg;
+use Composer\Pcre\UnexpectedNullMatchException;
 
 class ReplaceCallbackTest extends BaseTestCase
 {
@@ -58,6 +59,26 @@ class ReplaceCallbackTest extends BaseTestCase
 
         self::assertSame(0, $count);
         self::assertSame('def', $result);
+    }
+
+    public function testSuccessStrictGroups(): void
+    {
+        $result = Preg::replaceCallbackStrictGroups('{(?P<m>\d)(?<matched>a)?}', function ($match) {
+            return strtoupper($match['matched']);
+        }, '3a', -1, $count);
+
+        self::assertSame(1, $count);
+        self::assertSame('A', $result);
+    }
+
+    public function testFailStrictGroups(): void
+    {
+        self::expectException(UnexpectedNullMatchException::class);
+        self::expectExceptionMessage('Pattern "{(?P<m>\d)(?<unmatched>a)?}" had an unexpected unmatched group "unmatched", make sure the pattern always matches or use replaceCallback() instead.');
+
+        $result = Preg::replaceCallbackStrictGroups('{(?P<m>\d)(?<unmatched>a)?}', function ($match) {
+            return strtoupper($match['unmatched']);
+        }, '123', -1, $count);
     }
 
     public function testBadPatternThrowsIfWarningsAreNotThrowing(): void


### PR DESCRIPTION
3.x can rely on PREG_UNMATCHED_AS_NULL for preg_replace_callback so this is possible here.