### PR TITLE
Make nullable parameter types explicit

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -147,7 +147,7 @@ class Preg
      *
      * @param-out int<0, max> $count
      */
-    public static function replace($pattern, $replacement, $subject, int $limit = -1, int &$count = null): string
+    public static function replace($pattern, $replacement, $subject, int $limit = -1, ?int &$count = null): string
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {
@@ -174,7 +174,7 @@ class Preg
      *
      * @param-out int<0, max> $count
      */
-    public static function replaceCallback($pattern, callable $replacement, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    public static function replaceCallback($pattern, callable $replacement, $subject, int $limit = -1, ?int &$count = null, int $flags = 0): string
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {
@@ -203,7 +203,7 @@ class Preg
      *
      * @param-out int<0, max> $count
      */
-    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, ?int &$count = null, int $flags = 0): string
     {
         return self::replaceCallback($pattern, function (array $matches) use ($pattern, $replacement) {
             return $replacement(self::enforceNonNullMatches($pattern, $matches, 'replaceCallback'));
@@ -218,7 +218,7 @@ class Preg
      *
      * @param-out int<0, max> $count
      */
-    public static function replaceCallbackArray(array $pattern, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    public static function replaceCallbackArray(array $pattern, $subject, int $limit = -1, ?int &$count = null, int $flags = 0): string
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {


### PR DESCRIPTION
PHP allows to implicitly declare a nullable parameter type by setting the parameter's default value to `null`. However, in PHP 8.4 this syntax has been deprecated.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types