### PR TITLE
Add explicit nullable to `Preg::replaceCallbackStrictGroups` for PHP 8.4 compatibility

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -203,7 +203,7 @@ class Preg
      *
      * @param-out int<0, max> $count
      */
-    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, ?int &$count = null, int $flags = 0): string
     {
         return self::replaceCallback($pattern, function (array $matches) use ($pattern, $replacement) {
             return $replacement(self::enforceNonNullMatches($pattern, $matches, 'replaceCallback'));


### PR DESCRIPTION
Explicit nullable type have been added to the branch 2.x in https://github.com/composer/pcre/commit/28fb502a83ad3f7a50b19d8d53ef3ff86c8f8104, then merged into main.
But the method `Preg::replaceCallbackStrictGroups` was introduced in version 3.x (main branch) by https://github.com/composer/pcre/commit/317c8a52ccaa976e1ef8a99a7431e548f66a294a

This is the last occurrence.
```
$ php -l **/*.php
No syntax errors detected in ./tests/RegexTests/ReplaceCallbackTest.php
No syntax errors detected in ./tests/RegexTests/MatchAllTest.php
No syntax errors detected in ./tests/RegexTests/ReplaceCallbackArrayTest.php
No syntax errors detected in ./tests/RegexTests/ReplaceTest.php
No syntax errors detected in ./tests/RegexTests/MatchWithOffsetsTest.php
No syntax errors detected in ./tests/RegexTests/MatchTest.php
No syntax errors detected in ./tests/RegexTests/MatchAllWithOffsetsTest.php
No syntax errors detected in ./tests/RegexTests/IsMatchTest.php
No syntax errors detected in ./tests/PregTests/ReplaceCallbackTest.php
No syntax errors detected in ./tests/PregTests/MatchAllTest.php
No syntax errors detected in ./tests/PregTests/ReplaceCallbackArrayTest.php
No syntax errors detected in ./tests/PregTests/IsMatchWithOffsetsTest.php
No syntax errors detected in ./tests/PregTests/ReplaceTest.php
No syntax errors detected in ./tests/PregTests/SplitTest.php
No syntax errors detected in ./tests/PregTests/IsMatchAllTest.php
No syntax errors detected in ./tests/PregTests/GrepTest.php
No syntax errors detected in ./tests/PregTests/MatchTest.php
No syntax errors detected in ./tests/PregTests/IsMatchAllWithOffsetsTest.php
No syntax errors detected in ./tests/PregTests/SplitWithOffsetsTest.php
No syntax errors detected in ./tests/PregTests/IsMatchTest.php
No syntax errors detected in ./tests/phpstan-locate-phpunit-autoloader.php
No syntax errors detected in ./tests/BaseTestCase.php
No syntax errors detected in ./src/MatchResult.php
No syntax errors detected in ./src/Regex.php
No syntax errors detected in ./src/MatchAllWithOffsetsResult.php
No syntax errors detected in ./src/MatchWithOffsetsResult.php
No syntax errors detected in ./src/MatchAllStrictGroupsResult.php
No syntax errors detected in ./src/UnexpectedNullMatchException.php
No syntax errors detected in ./src/MatchStrictGroupsResult.php
No syntax errors detected in ./src/MatchAllResult.php
No syntax errors detected in ./src/ReplaceResult.php
PHP Deprecated:  Composer\Pcre\Preg::replaceCallbackStrictGroups(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in ./src/Preg.php on line 206

Deprecated: Composer\Pcre\Preg::replaceCallbackStrictGroups(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in ./src/Preg.php on line 206
No syntax errors detected in ./src/Preg.php
No syntax errors detected in ./src/PcreException.php
```