### PR TITLE
PHP 8.4 nullable type deprecation

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -198,12 +198,12 @@ class Preg
      * @param string $pattern
      * @param ($flags is PREG_OFFSET_CAPTURE ? (callable(array<int|string, array{string, int<0, max>}>): string) : callable(array<int|string, string>): string) $replacement
      * @param string $subject
-     * @param int $count Set by method
+     * @param ?int $count Set by method
      * @param int-mask<PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE> $flags PREG_OFFSET_CAPTURE is supported, PREG_UNMATCHED_AS_NULL is always set
      *
      * @param-out int<0, max> $count
      */
-    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, int &$count = null, int $flags = 0): string
+    public static function replaceCallbackStrictGroups(string $pattern, callable $replacement, $subject, int $limit = -1, ?int &$count = null, int $flags = 0): string
     {
         return self::replaceCallback($pattern, function (array $matches) use ($pattern, $replacement) {
             return $replacement(self::enforceNonNullMatches($pattern, $matches, 'replaceCallback'));


### PR DESCRIPTION
To avoid deprecation notices in PHP 8.4, use explicitly nullable types.

Without this change, the following deprecation notice has been observed in downstream projects in PHP 8.4:

```
Deprecation Notice: Composer\Pcre\Preg::replaceCallbackStrictGroups(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/composer/composer/vendor/composer/pcre/src/Preg.php:206
```