### PR TITLE
Add support for isMatch in phpstan type ext

### DIFF
--- a/src/PHPStan/PregMatchParameterOutTypeExtension.php
+++ b/src/PHPStan/PregMatchParameterOutTypeExtension.php
@@ -30,7 +30,7 @@ final class PregMatchParameterOutTypeExtension implements StaticMethodParameterO
     {
         return
             $methodReflection->getDeclaringClass()->getName() === Preg::class
-            && $methodReflection->getName() === 'match'
+            && in_array($methodReflection->getName(), ['match', 'isMatch'], true)
             && $parameter->getName() === 'matches';
     }
 

--- a/src/PHPStan/PregMatchTypeSpecifyingExtension.php
+++ b/src/PHPStan/PregMatchTypeSpecifyingExtension.php
@@ -43,7 +43,7 @@ final class PregMatchTypeSpecifyingExtension implements StaticMethodTypeSpecifyi
 
     public function isStaticMethodSupported(MethodReflection $methodReflection, StaticCall $node, TypeSpecifierContext $context): bool
     {
-        return $methodReflection->getName() === 'match' && !$context->null();
+        return in_array($methodReflection->getName(), ['match', 'isMatch'], true) && !$context->null();
     }
 
     public function specifyTypes(MethodReflection $methodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/tests/PHPStanTests/nsrt/preg-match.php
+++ b/tests/PHPStanTests/nsrt/preg-match.php
@@ -28,12 +28,12 @@ function doMatch(string $s): void
     }
     assertType('array{}|array{0: string, 1?: string|null}', $matches);
 
-    if (Preg::isMatch('/Price: (?P<currency>£|€)\d+/', $s, $matches)) {
-        assertType('array{0: string, 1: string|null, currency: string|null}', $matches);
+    if (Preg::isMatch('/Price: (?<currency>£|€)\d+/', $s, $matches)) {
+        assertType('array{0: string, currency: string|null, 1: string|null}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{0: string, 1?: string|null}', $matches);
+    assertType('array{}|array{0: string, currency: string|null, 1: string|null}', $matches);
 }
 
 // disabled until https://github.com/phpstan/phpstan-src/pull/3185 can be resolved

--- a/tests/PHPStanTests/nsrt/preg-match.php
+++ b/tests/PHPStanTests/nsrt/preg-match.php
@@ -27,6 +27,13 @@ function doMatch(string $s): void
         assertType('array{}', $matches);
     }
     assertType('array{}|array{0: string, 1?: string|null}', $matches);
+
+    if (Preg::isMatch('/Price: (?P<currency>£|€)\d+/', $s, $matches)) {
+        assertType('array{0: string, 1: string|null, currency: string|null}', $matches);
+    } else {
+        assertType('array{}', $matches);
+    }
+    assertType('array{}|array{0: string, 1?: string|null}', $matches);
 }
 
 // disabled until https://github.com/phpstan/phpstan-src/pull/3185 can be resolved


### PR DESCRIPTION
@staabm sorry to bug you again but any clue why this does not work?

Ideally we'd have support for:

- isMatch (like match but returns bool instead of 0|1)
- matchStrictGroups (like match but makes sure all match groups are non-null if it matched)
- isMatchStrictGroups (same as above but returns bool instead of 0|1)
- all the above in matchAll variants 

But at least isMatch would be great because that's used all over the place (I never use match as it returns int), and it is API compatible with match so I don't get why this fails.