### PR TITLE
Strict groups support

### DIFF
--- a/src/PHPStan/PregMatchParameterOutTypeExtension.php
+++ b/src/PHPStan/PregMatchParameterOutTypeExtension.php
@@ -30,7 +30,7 @@ final class PregMatchParameterOutTypeExtension implements StaticMethodParameterO
     {
         return
             $methodReflection->getDeclaringClass()->getName() === Preg::class
-            && in_array($methodReflection->getName(), ['match', 'isMatch'], true)
+            && in_array($methodReflection->getName(), ['match', 'isMatch', 'matchStrictGroups', 'isMatchStrictGroups'], true)
             && $parameter->getName() === 'matches';
     }
 

--- a/src/PHPStan/PregMatchTypeSpecifyingExtension.php
+++ b/src/PHPStan/PregMatchTypeSpecifyingExtension.php
@@ -43,7 +43,7 @@ final class PregMatchTypeSpecifyingExtension implements StaticMethodTypeSpecifyi
 
     public function isStaticMethodSupported(MethodReflection $methodReflection, StaticCall $node, TypeSpecifierContext $context): bool
     {
-        return in_array($methodReflection->getName(), ['match', 'isMatch'], true) && !$context->null();
+        return in_array($methodReflection->getName(), ['match', 'isMatch', 'matchStrictGroups', 'isMatchStrictGroups'], true) && !$context->null();
     }
 
     public function specifyTypes(MethodReflection $methodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/PHPStan/PregMatchTypeSpecifyingExtension.php
+++ b/src/PHPStan/PregMatchTypeSpecifyingExtension.php
@@ -11,8 +11,11 @@ use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Php\RegexArrayShapeMatcher;
 use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\Type;
 
 final class PregMatchTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
@@ -68,6 +71,22 @@ final class PregMatchTypeSpecifyingExtension implements StaticMethodTypeSpecifyi
         $matchedType = $this->regexShapeMatcher->matchType($patternType, $flagsType, TrinaryLogic::createFromBoolean($context->true()));
         if ($matchedType === null) {
             return new SpecifiedTypes();
+        }
+
+        if (
+            in_array($methodReflection->getName(), ['matchStrictGroups', 'isMatchStrictGroups'], true)
+            && count($matchedType->getConstantArrays()) > 0
+        ) {
+            $matchedType = $matchedType->getConstantArrays()[0];
+            $matchedType = new ConstantArrayType(
+                $matchedType->getKeyTypes(),
+                array_map(static function (Type $valueType): Type {
+                    return TypeCombinator::removeNull($valueType);
+                }, $matchedType->getValueTypes()),
+                [0],
+                [],
+                $matchedType->isList()
+            );
         }
 
         $overwrite = false;

--- a/tests/PHPStanTests/nsrt/preg-match.php
+++ b/tests/PHPStanTests/nsrt/preg-match.php
@@ -36,6 +36,30 @@ function doMatch(string $s): void
     assertType('array{}|array{0: string, currency: string|null, 1: string|null}', $matches);
 }
 
+function doMatchStrictGroups(string $s): void
+{
+    if (Preg::matchStrictGroups('/Price: /i', $s, $matches)) {
+        assertType('array{string}', $matches);
+    } else {
+        assertType('array{}', $matches);
+    }
+    assertType('array{}|array{string}', $matches);
+
+    if (Preg::matchStrictGroups('/Price: (£|€)\d+/', $s, $matches)) {
+        assertType('array{string, string}', $matches);
+    } else {
+        assertType('array{}', $matches);
+    }
+    assertType('array{}|array{string, string}', $matches);
+
+    if (Preg::isMatchStrictGroups('/Price: (£|€)?\d+/', $s, $matches)) {
+        assertType('array{string, string}', $matches);
+    } else {
+        assertType('array{}', $matches);
+    }
+    assertType('array{}|array{string, string}', $matches);
+}
+
 // disabled until https://github.com/phpstan/phpstan-src/pull/3185 can be resolved
 //
 //function identicalMatch(string $s): void

--- a/tests/PHPStanTests/nsrt/preg-match.php
+++ b/tests/PHPStanTests/nsrt/preg-match.php
@@ -52,12 +52,12 @@ function doMatchStrictGroups(string $s): void
     }
     assertType('array{}|array{string, string}', $matches);
 
-    if (Preg::isMatchStrictGroups('/Price: (£|€)?\d+/', $s, $matches)) {
-        assertType('array{string, string}', $matches);
+    if (Preg::isMatchStrictGroups('/Price: (?<test>£|€)\d+/', $s, $matches)) {
+        assertType('array{0: string, test: string, 1: string}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{string, string}', $matches);
+    assertType('array{}|array{0: string, test: string, 1: string}', $matches);
 }
 
 // disabled until https://github.com/phpstan/phpstan-src/pull/3185 can be resolved


### PR DESCRIPTION
@staabm 

> I think these should be doable in a similar way you did in this PR

I am not sure how to do the non-null part. Maybe it's doable by modifying the result of `$this->regexShapeMatcher->matchType()` to ensure `string|null` becomes `string`.. but I suck at phpstan internals :D 

If you have a sec to help any time it'd be great, I believe the tests are correct.