### PR TITLE
Enable PHPStan Extensions outside of bleeding edge

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -3,19 +3,15 @@
 # These can be reused by third party packages by including 'vendor/composer/pcre/extension.neon'
 # in your phpstan config
 
-conditionalTags:
-    Composer\Pcre\PHPStan\PregMatchParameterOutTypeExtension:
-        phpstan.staticMethodParameterOutTypeExtension: %featureToggles.narrowPregMatches%
-    Composer\Pcre\PHPStan\PregMatchTypeSpecifyingExtension:
-        phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension: %featureToggles.narrowPregMatches%
-    Composer\Pcre\PHPStan\UnsafeStrictGroupsCallRule:
-        phpstan.rules.rule: %featureToggles.narrowPregMatches%
-
 services:
     -
         class: Composer\Pcre\PHPStan\PregMatchParameterOutTypeExtension
+        tags:
+            - phpstan.staticMethodParameterOutTypeExtension
     -
         class: Composer\Pcre\PHPStan\PregMatchTypeSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
 
 rules:
     - Composer\Pcre\PHPStan\UnsafeStrictGroupsCallRule


### PR DESCRIPTION
ondrej enabled the preg-match $matches inference feature with 1.12.x by default as it seems [stable enough for general use](https://github.com/phpstan/phpstan-src/commit/bd2cec118592f7c66dff5a7ae28882654daf6468#commitcomment-144887406).

the feature flag `%featureToggles.narrowPregMatches%` we rely on will be dropped with 1.12.

so there are 2 possible ways to handle it:
1) we re-introduce the feature-flag as a noop in PHPstan 1.12.x as [suggested by ondrej](https://github.com/phpstan/phpstan-src/commit/bd2cec118592f7c66dff5a7ae28882654daf6468#commitcomment-144900356)
2) we remove usage of the feature flag, as we think the feature is already stable enough (so PHPStan-src 1.12.x does not need to take care of us using a non BC promise feature-flag)

@Seldaek wdyt about this options. do you feel confident to remove the feature flag for bleeding edge already within composer/pcre?