### PR TITLE
Add failing test for matchAllStrictGroups

### DIFF
--- a/tests/PHPStanTests/nsrt/preg-match.php
+++ b/tests/PHPStanTests/nsrt/preg-match.php
@@ -110,6 +110,10 @@ function doMatchAllStrictGroups(string $s): void
         assertType('array{}', $matches);
     }
     assertType('array{}|array{0: list<string>, test: list<non-empty-string>, 1: list<non-empty-string>}', $matches);
+
+    if (Preg::isMatchAllStrictGroups('/Price: (?<test>£|€)?\d+/', $s, $matches)) {
+        assertType('array{0: list<string>, test: list<non-empty-string>, 1: list<non-empty-string>}', $matches);
+    }
 }
 
 // disabled until https://github.com/phpstan/phpstan-src/pull/3185 can be resolved


### PR DESCRIPTION
@staabm maybe whenever you have time you can have a look (after vacation! Really not urgent) here.

I tried adding the matchAll variants here https://github.com/composer/pcre/blob/5cc3c12e20f5ed14a45a481b474f7b9788156979/src/PHPStan/PregMatchTypeSpecifyingExtension.php#L85 but this does not help as it marks the wrong thing not-null I believe.

There is a secondary similar problem to this on the main branch with offset capture https://github.com/composer/pcre/commit/5cc3c12e20f5ed14a45a481b474f7b9788156979#diff-0809405debfb0987519b2d18d3b011f43563ef0ae298e425bd1c931f4b83e3a1R99 whereas this code here is not smart enough to handle the capture array shape https://github.com/composer/pcre/commit/5cc3c12e20f5ed14a45a481b474f7b9788156979#diff-decc762a6a5c114c9d14da4184465733952f6cf8c38f2b4afe7d82d3832169ecR59-R70
