### PR TITLE
feat: apply return type from strict param

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -11,6 +11,10 @@
 
 namespace Composer\Pcre;
 
+use InvalidArgumentException;
+use TypeError;
+use Stringable;
+
 class Preg
 {
     /** @internal */
@@ -151,10 +155,10 @@ class Preg
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {
-                throw new \InvalidArgumentException(static::ARRAY_MSG);
+                throw new InvalidArgumentException(static::ARRAY_MSG);
             }
 
-            throw new \TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
+            throw new TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
         }
 
         $result = preg_replace($pattern, $replacement, $subject, $limit, $count);
@@ -178,10 +182,10 @@ class Preg
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {
-                throw new \InvalidArgumentException(static::ARRAY_MSG);
+                throw new InvalidArgumentException(static::ARRAY_MSG);
             }
 
-            throw new \TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
+            throw new TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
         }
 
         $result = preg_replace_callback($pattern, $replacement, $subject, $limit, $count, $flags | PREG_UNMATCHED_AS_NULL);
@@ -222,10 +226,10 @@ class Preg
     {
         if (!is_scalar($subject)) {
             if (is_array($subject)) {
-                throw new \InvalidArgumentException(static::ARRAY_MSG);
+                throw new InvalidArgumentException(static::ARRAY_MSG);
             }
 
-            throw new \TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
+            throw new TypeError(sprintf(static::INVALID_TYPE_MSG, gettype($subject)));
         }
 
         $result = preg_replace_callback_array($pattern, $subject, $limit, $count, $flags | PREG_UNMATCHED_AS_NULL);
@@ -244,7 +248,7 @@ class Preg
     public static function split(string $pattern, string $subject, int $limit = -1, int $flags = 0): array
     {
         if (($flags & PREG_SPLIT_OFFSET_CAPTURE) !== 0) {
-            throw new \InvalidArgumentException('PREG_SPLIT_OFFSET_CAPTURE is not supported as it changes the type of $matches, use splitWithOffsets() instead');
+            throw new InvalidArgumentException('PREG_SPLIT_OFFSET_CAPTURE is not supported as it changes the type of $matches, use splitWithOffsets() instead');
         }
 
         $result = preg_split($pattern, $subject, $limit, $flags);
@@ -271,7 +275,7 @@ class Preg
     }
 
     /**
-     * @template T of string|\Stringable
+     * @template T of string|Stringable
      * @param string   $pattern
      * @param array<T> $array
      * @param int-mask<PREG_GREP_INVERT> $flags PREG_GREP_INVERT
@@ -379,14 +383,14 @@ class Preg
     private static function checkOffsetCapture(int $flags, string $useFunctionName): void
     {
         if (($flags & PREG_OFFSET_CAPTURE) !== 0) {
-            throw new \InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the type of $matches, use ' . $useFunctionName . '() instead');
+            throw new InvalidArgumentException('PREG_OFFSET_CAPTURE is not supported as it changes the type of $matches, use ' . $useFunctionName . '() instead');
         }
     }
 
     private static function checkSetOrder(int $flags): void
     {
         if (($flags & PREG_SET_ORDER) !== 0) {
-            throw new \InvalidArgumentException('PREG_SET_ORDER is not supported as it changes the type of $matches');
+            throw new InvalidArgumentException('PREG_SET_ORDER is not supported as it changes the type of $matches');
         }
     }
 
@@ -395,7 +399,7 @@ class Preg
      * @return array<int|string, string>
      * @throws UnexpectedNullMatchException
      */
-    private static function enforceNonNullMatches(string $pattern, array $matches, string $variantMethod)
+    private static function enforceNonNullMatches(string $pattern, array $matches, string $variantMethod): array
     {
         foreach ($matches as $group => $match) {
             if (is_string($match) || (is_array($match) && is_string($match[0]))) {
@@ -414,7 +418,7 @@ class Preg
      * @return array<int|string, list<string>>
      * @throws UnexpectedNullMatchException
      */
-    private static function enforceNonNullMatchAll(string $pattern, array $matches, string $variantMethod)
+    private static function enforceNonNullMatchAll(string $pattern, array $matches, string $variantMethod): array
     {
         foreach ($matches as $group => $groupMatches) {
             foreach ($groupMatches as $match) {


### PR DESCRIPTION
Apply rector rule [ReturnTypeFromStrictParam](https://getrector.com/rule-detail/return-type-from-strict-param-rector) over src/Preg.php


This is the first pull request in a series aimed at addressing deprecations in PHP 8.4. I will be sending the full list shortly:

```
Deprecation Notice: Constant E_STRICT is deprecated in phar:///usr/local/bin/composer/src/Composer/Util/Silencer.php:36
Deprecation Notice: Composer\Pcre\Preg::replace(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/pcre/src/Preg.php:150
Deprecation Notice: Composer\Pcre\Preg::replaceCallback(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/pcre/src/Preg.php:177
Deprecation Notice: Composer\Pcre\Preg::replaceCallbackArray(): Implicitly marking parameter $count as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/pcre/src/Preg.php:207
Deprecation Notice: JsonSchema\Constraints\BaseConstraint::__construct(): Implicitly marking parameter $factory as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/BaseConstraint.php:41
Deprecation Notice: JsonSchema\Constraints\BaseConstraint::addError(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/BaseConstraint.php:46
Deprecation Notice: JsonSchema\Constraints\BaseConstraint::addError(): Implicitly marking parameter $more as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/BaseConstraint.php:46
Deprecation Notice: JsonSchema\Constraints\Factory::__construct(): Implicitly marking parameter $schemaStorage as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Factory.php:76
Deprecation Notice: JsonSchema\Constraints\Factory::__construct(): Implicitly marking parameter $uriRetriever as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Factory.php:76
Deprecation Notice: JsonSchema\Constraints\Constraint::incrementPath(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:42
Deprecation Notice: JsonSchema\Constraints\Constraint::checkArray(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:68
Deprecation Notice: JsonSchema\Constraints\Constraint::checkObject(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:86
Deprecation Notice: JsonSchema\Constraints\Constraint::checkType(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:103
Deprecation Notice: JsonSchema\Constraints\Constraint::checkUndefined(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:119
Deprecation Notice: JsonSchema\Constraints\Constraint::checkString(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:136
Deprecation Notice: JsonSchema\Constraints\Constraint::checkNumber(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:152
Deprecation Notice: JsonSchema\Constraints\Constraint::checkEnum(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:168
Deprecation Notice: JsonSchema\Constraints\Constraint::checkFormat(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/Constraint.php:184
Deprecation Notice: JsonSchema\Constraints\ConstraintInterface::addError(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ConstraintInterface.php:43
Deprecation Notice: JsonSchema\Constraints\ConstraintInterface::addError(): Implicitly marking parameter $more as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ConstraintInterface.php:43
Deprecation Notice: JsonSchema\Constraints\ConstraintInterface::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ConstraintInterface.php:64
Deprecation Notice: JsonSchema\SchemaStorage::__construct(): Implicitly marking parameter $uriRetriever as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/SchemaStorage.php:19
Deprecation Notice: JsonSchema\SchemaStorage::__construct(): Implicitly marking parameter $uriResolver as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/SchemaStorage.php:19
Deprecation Notice: JsonSchema\Constraints\SchemaConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/SchemaConstraint.php:31
Deprecation Notice: JsonSchema\Constraints\UndefinedConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/UndefinedConstraint.php:34
Deprecation Notice: JsonSchema\Constraints\TypeConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/TypeConstraint.php:42
Deprecation Notice: JsonSchema\Constraints\ObjectConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ObjectConstraint.php:30
Deprecation Notice: JsonSchema\Constraints\ObjectConstraint::validatePatternProperties(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ObjectConstraint.php:54
Deprecation Notice: JsonSchema\Constraints\ObjectConstraint::validateElement(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ObjectConstraint.php:93
Deprecation Notice: JsonSchema\Constraints\ObjectConstraint::validateProperties(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ObjectConstraint.php:135
Deprecation Notice: JsonSchema\Constraints\ObjectConstraint::validateMinMaxConstraint(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/ObjectConstraint.php:177
Deprecation Notice: JsonSchema\Constraints\StringConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/StringConstraint.php:25
Deprecation Notice: JsonSchema\Constraints\FormatConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/FormatConstraint.php:27
Deprecation Notice: JsonSchema\Constraints\EnumConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/EnumConstraint.php:25
Deprecation Notice: JsonSchema\Constraints\CollectionConstraint::check(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/CollectionConstraint.php:25
Deprecation Notice: JsonSchema\Constraints\CollectionConstraint::validateItems(): Implicitly marking parameter $path as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/CollectionConstraint.php:64
Deprecation Notice: Constant E_STRICT is deprecated in phar:///usr/local/bin/composer/src/Composer/Util/Silencer.php:36
Deprecation Notice: Constant E_STRICT is deprecated in phar:///usr/local/bin/composer/src/Composer/Util/Silencer.php:36
Deprecation Notice: Composer\CaBundle\CaBundle::getSystemCaRootBundlePath(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:67
Deprecation Notice: Composer\CaBundle\CaBundle::validateCaFile(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:163
Deprecation Notice: Composer\CaBundle\CaBundle::caFileUsable(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:343
Deprecation Notice: Composer\CaBundle\CaBundle::caDirUsable(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:356
Deprecation Notice: Composer\CaBundle\CaBundle::isFile(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:369
Deprecation Notice: Composer\CaBundle\CaBundle::isDir(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:384
Deprecation Notice: Composer\CaBundle\CaBundle::isReadable(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:399
Deprecation Notice: Composer\CaBundle\CaBundle::glob(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/ca-bundle/src/CaBundle.php:414
Deprecation Notice: Composer\Util\Git::fetchRefOrSyncMirror(): Implicitly marking parameter $prettyVersion as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/src/Composer/Util/Git.php:301
Deprecation Notice: Composer\ClassMapGenerator\ClassMapGenerator::avoidDuplicateScans(): Implicitly marking parameter $scannedFiles as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/class-map-generator/src/ClassMapGenerator.php:64
Deprecation Notice: Composer\ClassMapGenerator\ClassMapGenerator::scanPaths(): Implicitly marking parameter $excluded as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/local/bin/composer/vendor/composer/class-map-generator/src/ClassMapGenerator.php:103
Deprecation Notice: Constant E_STRICT is deprecated in phar:///usr/local/bin/composer/src/Composer/Util/Silencer.php:36
```