### PR TITLE
Fix 2.x CI: split preg-match nsrt test by PHP/PHPStan version

### DIFF
--- a/tests/PHPStanTests/nsrt/preg-match-php7.2.php
+++ b/tests/PHPStanTests/nsrt/preg-match-php7.2.php
@@ -1,4 +1,4 @@
-<?php // lint >= 7.4
+<?php // lint < 7.4
 
 namespace PregMatchShapes;
 
@@ -9,71 +9,71 @@ use function PHPStan\Testing\assertType;
 function doMatch(string $s): void
 {
     if (Preg::match('/Price: /i', $s, $matches)) {
-        assertType('array{non-falsy-string}', $matches);
+        assertType('array{string}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string}', $matches);
+    assertType('array{}|array{string}', $matches);
 
     if (Preg::match('/Price: (£|€)\d+/', $s, $matches)) {
-        assertType('array{non-falsy-string, \'£\'|\'€\'}', $matches);
+        assertType('array{string, \'£\'|\'€\'}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string, \'£\'|\'€\'}', $matches);
+    assertType('array{}|array{string, \'£\'|\'€\'}', $matches);
 
     if (Preg::match('/Price: (£|€)?\d+/', $s, $matches)) {
-        assertType('array{non-falsy-string, \'£\'|\'€\'|null}', $matches);
+        assertType('array{string, \'£\'|\'€\'|null}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string, \'£\'|\'€\'|null}', $matches);
+    assertType('array{}|array{string, \'£\'|\'€\'|null}', $matches);
 
     // passing the PREG_UNMATCHED_AS_NULL should change nothing compared to above as it is always set
     if (Preg::match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-        assertType('array{non-falsy-string, \'£\'|\'€\'|null}', $matches);
+        assertType('array{string, \'£\'|\'€\'|null}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string, \'£\'|\'€\'|null}', $matches);
+    assertType('array{}|array{string, \'£\'|\'€\'|null}', $matches);
 
     if (Preg::isMatch('/Price: (?<currency>£|€)\d+/', $s, $matches)) {
-        assertType('array{0: non-falsy-string, currency: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
+        assertType('array{0: string, currency: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{0: non-falsy-string, currency: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
+    assertType('array{}|array{0: string, currency: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
 }
 
 function doMatchStrictGroups(string $s): void
 {
     if (Preg::matchStrictGroups('/Price: /i', $s, $matches)) {
-        assertType('array{non-falsy-string}', $matches);
+        assertType('array{string}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string}', $matches);
+    assertType('array{}|array{string}', $matches);
 
     if (Preg::matchStrictGroups('/Price: (£|€)\d+/', $s, $matches)) {
-        assertType('array{non-falsy-string, \'£\'|\'€\'}', $matches);
+        assertType('array{string, \'£\'|\'€\'}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{non-falsy-string, \'£\'|\'€\'}', $matches);
+    assertType('array{}|array{string, \'£\'|\'€\'}', $matches);
 
     if (Preg::isMatchStrictGroups('/Price: (?<test>£|€)\d+/', $s, $matches)) {
-        assertType('array{0: non-falsy-string, test: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
+        assertType('array{0: string, test: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
     } else {
         assertType('array{}', $matches);
     }
-    assertType('array{}|array{0: non-falsy-string, test: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
+    assertType('array{}|array{0: string, test: \'£\'|\'€\', 1: \'£\'|\'€\'}', $matches);
 }
 
 function doMatchStrictGroupsUnsafe(string $s): void
 {
     if (Preg::isMatchStrictGroups('{Configure Command(?: *</td><td class="v">| *=> *)(.*)(?:</td>|$)}m', $s, $matches)) {
         // does not error because the match group might be empty but is not optional
-        assertType('array{non-falsy-string, string}', $matches);
+        assertType('array{string, string}', $matches);
     }
 
     // should error as it is unsafe due to the optional group 1


### PR DESCRIPTION
## Context

This started as a request to backport composer/pcre@d25621a ("Update phpstan tests to latest phpstan features") to `2.x` to fix the red CI. On investigation, **that commit is already effectively present on `2.x`** (it landed via `bfa9e76`), and it is actually the *cause* of the failure rather than the fix.

## Root cause

The failing job is `phpunit --testsuite phpstan`. The genuine failures occur only on **PHP 7.2 / 7.3** (the 8.x reds are fail-fast cancellations). `2.x` supports `php: ^7.2 || ^8.0`, but PHPStan 2.x requires PHP ≥ 7.4 — so on 7.2/7.3 `composer --highest` installs **PHPStan 1.12**, which infers plain `string` instead of `non-falsy-string`.

All 17 failures were in `tests/PHPStanTests/nsrt/preg-match.php`, the only nsrt file with **no `// lint` directive**, so it ran on every PHP version. The sibling `preg-replace-callback` test already handles this with a `// lint >= 7.4` / `// lint < 7.4` split.

## Change

- Gate `preg-match.php` to `// lint >= 7.4` (keeps the `non-falsy-string` expectations for PHPStan 2.x).
- Add `preg-match-php7.2.php` with `// lint < 7.4` holding the plain-`string` expectations for PHPStan 1.12.

This mirrors the existing `preg-replace-callback.php` / `preg-replace-callback-php7.2.php` pattern. No production/`src` changes. Verified locally on PHP 8.4 (`--testsuite phpstan` green, 43 tests); the 7.2/7.3 side is exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)