### PR TITLE
Drop PHPUnit 8 (only required for PHP 7.2+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8 || ^9",
+        "phpunit/phpunit": "^9",
         "phpstan/phpstan": "^1.12 || ^2",
         "phpstan/phpstan-strict-rules": "^1 || ^2",
         "phpstan/phpstan-deprecation-rules": "^1 || ^2"


### PR DESCRIPTION
since this package has php min version of 7.4+, PHPUnit 9.x is enough to cover all supported php versions